### PR TITLE
Update ModActions model class in database.py

### DIFF
--- a/src/astrofeed_lib/database.py
+++ b/src/astrofeed_lib/database.py
@@ -86,7 +86,7 @@ class ModActions(BaseModel):
     did_mod = peewee.CharField(index=True, null=False)
     did_user = peewee.CharField(index=True)
     action = peewee.CharField(index=True, null=False)
-    expiry = peewee.DateTimeField(index=True)
+    expiry = peewee.DateTimeField(index=True, null=True)
 
 
 


### PR DESCRIPTION
Adding "null=True" to the arguments of `ModActions.checked_at` field declaration, to allow null values to be entered into the database through peewee.