### PR TITLE
add feature: local building of developer database from given source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# local database files
+*.db

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev_db = [
-  "pandas==2.2.2" # If (re-)building the developer database
+  "pandas>=2.0,<3" # If (re-)building the developer database
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ dependencies = [
   "websockets>=13.0"  # Has a faster async implementation than others
 ]
 
+[project.optional-dependencies]
+dev_db = [
+  "pandas==2.2.2" # If (re-)building the developer database
+]
+
 [project.urls]
 "Homepage" = "https://astronomy.blue/"
 "Bug Reports" = "https://github.com/bluesky-astronomy/astrofeed-lib"

--- a/src/astrofeed_lib/dev_database.py
+++ b/src/astrofeed_lib/dev_database.py
@@ -1,250 +1,13 @@
-from __future__ import annotations
-
 import os
 import numpy
 import pandas
 import peewee
+import warnings
 
 from datetime import datetime
 
 ##
-## main function to be used outside of this module
-##
-def build_dev_db(data_source : str):
-    """
-        given a string representing a source of data, and (optionally) a string for the 
-        name of a database file, populate the database file with data from the specified
-        source
-
-        in:
-            data_source: string that currently must locate a directory containing parquet 
-                         files titled Account.parquet, Post.parquet, BotActions.parquet, 
-                         ModActions.parquet, and SubscriptionState.parquet
-                         
-    """
-
-    main_db = get_db_as_dict(data_source)
-    dev_db = truncate_db(main_db, take_num=50000, sampling="last")
-    dev_db = clean_db(dev_db)
-
-    # connect to database
-    db_conn = peewee.SqliteDatabase("dev_db.db")
-    BaseModel._meta.database.initialize(db_conn)
-
-    # now that it's set up, swap to our database, write the data, then swap back
-    write_dict = {
-        Account           : dev_db["Account"],
-        Post              : dev_db["Post"],
-        BotActions        : dev_db["BotActions"],
-        ModActions        : dev_db["ModActions"],
-        SubscriptionState : dev_db["SubscriptionState"]
-    }
-    db_conn.create_tables([model for model in write_dict.keys()])
-    batch_write_to_db(write_dict)
-
-
-##
-## auxilliary functions for internal use
-##
-
-
-
-def get_db_as_dict(source : str, source_format : str = "parquet"):
-    """ 
-        given a string representing a source to read data from, and another string
-        indicating the format of that source: produce a dictionary linking labels for 
-        ingested tables to dataframes containing the entries in those tables
-
-        in:
-            source       : string specifying the location of data to read in
-            source_format: string indicating format data is stored in
-
-        out:
-            db: dictionary with names of source tables as keys, and dataframes containing 
-                those tables' data as values
-            
-    """
-
-    # initial housekeeping
-    source_formats  = ["parquet"]
-    planned_formats = ["mysql"]
-    source_format   = source_format.lower()
-
-
-    # now we can build the dictionary!
-    db = dict()
-
-    match source_format:
-        case "parquet":
-            # assume we are given a directory of tablename.parquet files, or a single tablename.parquet file
-            if os.path.isdir(source):
-                for filename in os.listdir(source):
-                    tablename = os.path.splitext(filename)[0]
-                    db[tablename] = pandas.read_parquet(source + "/" + filename)
-            else:
-                tablename = os.path.splitext(source)
-                db[tablename] = pandas.read_parquet(source)
-
-        case _:
-            # default case if nothing is matched --- haven't implenented the requested format
-            if source_format in planned_formats:
-                errmsg = f"dev_database/get_db_as_dict: {source_format} is not yet implemented, but it is planned for the future!\nFor now, please use one of the following: {source_formats}"
-            else:
-                errmsg = f"dev_database/get_db_as_dict: {source_format} not a supported format, please use one of the following: {source_formats}"
-            raise NotImplementedError(errmsg)
-
-    return db
-
-def truncate_db(db : dict[str, pandas.DataFrame], take_num : int = 0, take_frac : float = 0, sampling : str = "last"):
-    """ 
-        given a database with Post, Account, ModActions, BotActions, and SubscriptionState tables, 
-        return a truncated database by sampling from Post, then finding all entries in other tables 
-        related to sampled Post entries
-
-        in:
-            db       : dictionary of table labels and corresponding dataframes
-            take_num : number of Post entries to truncate to
-            take_frac: fraction of Post entries to truncate to
-            sampling : whether to take {first, last, random} take_num entries from Post
-
-        out:
-            trunc_db: output dictionary (same structure as input), with truncated Post data and relevant entries 
-                      from other dataframes
-            
-    """
-
-    # make sure our take_num/take_frac make sense
-    if(((take_num!=0) == (take_frac!=0)) or (take_num < 0 or take_frac < 0)):
-        raise ValueError(f"dev_database/truncate_db: must specify a positive (nonzero) value for only one of take_num or take_frac in the argument list.")
-    elif(take_num > 0):
-        total_posts = len(db["Post"])
-        if(take_num > total_posts):
-            print(f"dev_database/truncate_db: {take_num} Post entries requested, but only {total_posts} available. Setting take_num={total_posts}")
-            take_num = total_posts
-    else:
-        if(take_frac > 1):
-            print("dev_database/truncate_db: take_frac is > 1.0, setting take_frac=1.0")
-            take_frac = 1.0
-        take_num = round(take_frac*len(db["Post"]))
-
-    # only three sampling strategies implemented, default to last n posts
-    if(sampling not in ["first", "last", "random"]):
-        print("dev_database/truncate_db: Sampling must be 'first', 'last', or 'random'; setting sampling='last'")
-        sampling = "last"
-
-    # initial sampling of Post
-    trunc_db = dict()
-    match sampling:
-        case "last":
-            icut = len(db["Post"]) - take_num
-            trunc_db["Post"] = db["Post"].iloc[icut:]
-        case "first":
-            trunc_db["Post"] = db["Post"].iloc[:take_num]
-        case "random":
-            trunc_db["Post"] = db["Post"].sample(n=take_num)
-
-    # next, we get unique user ids from those posts, and find which mod actions involved those users
-    user_dids = set(trunc_db["Post"]["author"])
-    trunc_db["ModActions"] = db["ModActions"][db["ModActions"]["did_user"].isin(user_dids)]
-
-    # then, the full set of relevant DIDs are those user DIDs, and the DIDs of mods involved in those actions
-    mod_dids = set(trunc_db["ModActions"]["did_mod"])
-    dids = user_dids.union(mod_dids)
-
-    # now with our full set of DIDs, we can retrieve all of the relevant data from the other tables
-    trunc_db["ModActions"       ] = db["ModActions"       ][db["ModActions"]["did_user"].isin(dids)] # for mods on user end of mod actions
-    trunc_db["BotActions"       ] = db["BotActions"       ][db["BotActions"]["did"     ].isin(dids)]
-    trunc_db["Account"          ] = db["Account"          ][db["Account"   ]["did"     ].isin(dids)]
-    trunc_db["SubscriptionState"] = db["SubscriptionState"] # no selection necessary here, it's only one entry (for now)
-
-    return trunc_db
-
-def clean_db(db : dict[str, pandas.DataFrame]):
-    """ 
-        given a database, return a copy of the database with type conversions applied and replacement values inserted, 
-        where necessary
-
-        in:
-            db: input database, as a dictionary of table labels, and corresponding dataframes holding the data
-
-        out:
-            clean_db: output database (same structure as input), with conversions and corrections applied
-            
-    """
-
-    clean_db = dict()
-
-    # db will be a dict, with each key leading to a dataframe
-    for table in db.keys():
-        df = db[table]
-
-        # loop through df columns, and swap old columns for new
-        for column in df.columns:
-            # different replacement needs for different columns
-            match column:
-                case "indexed_at":
-                    replacement_label = "indexed_at"
-
-                    # make copy of column in python date-time format
-                    replacement_data = df["indexed_at"].dt.to_pydatetime()
-                    replacement_data = pandas.Series(replacement_data, dtype=object)
-
-                case "checked_at":
-                    replacement_label = "checked_at"
-
-                    # possibly will be all-zeroes entries that we can't convert correctly,
-                    # replace those before conversion
-                    date_strings = df["checked_at"]
-                    for i in range(len(date_strings)):
-                        if date_strings.iloc[i] == "0000-00-00 00:00:00":
-                            date_strings.iloc[i] = "0001-01-01 00:00:01"
-
-                    replacement_data = pandas.Series([datetime.strptime(date_strings.iloc[i], "%Y-%m-%d %H:%M:%S") for i in range(len(date_strings))])
-
-                case _: # default
-                    continue
-
-            # reindex the dataframe to match the replacement data
-            df = df.set_index(replacement_data.index)
-
-            # swap columns
-            column_loc = df.columns.get_loc(replacement_label)
-            df = df.drop(replacement_label, axis=1)
-            df.insert(column_loc, replacement_label, replacement_data)
-
-        # now we can fill the new database
-        clean_db[table] = df
-
-    return clean_db
-
-def batch_write_to_db(write_dict : dict[BaseModel, pandas.DataFrame]):
-    """ 
-        given database model classes and associated dataframes, efficiently enter the data from the dataframes into 
-        the corresponding database tables using peewee
-
-        in:
-            write_dict: dictionary associating classes (representing models/tables in a database) with dataframes 
-                        containing entries that should be entered into the database            
-
-    """
-
-    for model,df in zip(write_dict.keys(), write_dict.values()):
-        # get database from model (and perform final security check before writing...
-        # REALLY don't want to be accessing the production database here):
-        db = model._meta.database
-        if type(db) is peewee.MySQLDatabase:
-            raise ConnectionRefusedError("dev_database/batch_write_to_db: trying to write with a MySQL database connection, aborting.")
-
-        # get the fields from the model
-        model_fields = list(model._meta.fields.values())
-
-        # atomic batched write
-        with db.atomic():
-            for batch in peewee.chunked(df.iloc[:,:].itertuples(index=False), 100):
-                model.insert_many(rows=batch, fields=model_fields).execute()
-
-##
-## copies of database.py functions, initialized with a DataBaseProxy (for future flexibility)
+## copies of database.py classes, initialized with a DataBaseProxy (for future flexibility)
 ## 
 
 class BaseModel(peewee.Model):
@@ -321,3 +84,191 @@ class ModActions(BaseModel):
     did_user = peewee.CharField(index=True)
     action = peewee.CharField(index=True, null=False)
     expiry = peewee.DateTimeField(index=True, null=True)
+
+##
+## main class that contains logic/methods for interacting with developer database, and data source to truncate from
+##
+class DB():
+    # hard coding this structure for now, but maybe i can find everything in the namespace that is a subclass 
+    # of BaseModel to build this programmatically?
+    models = dict({
+        "Account"           : Account,
+        "Post"              : Post,
+        "BotActions"        : BotActions,
+        "ModActions"        : ModActions,
+        "SubscriptionState" : SubscriptionState
+    })
+
+    # which is currently supported
+    supported_source_formats      = ["parquet"]
+    supported_sampling_strategies = ["first", "last", "random"]
+
+    def __init__(self, db_conn : peewee.Database):
+        # given a database connection, set our model classes to use it
+        BaseModel._meta.database.initialize(db_conn)
+
+        # make empty dictionary to hold dataframes
+        self.data = dict()
+
+    def populate_from_source(self, source: str, format: str = "parquet"):
+        """ 
+            given a string representing a source to read data from, and another string indicating the format 
+            of data at that source: set data in tables from source
+            
+        """
+
+        format = format.lower()
+        match format:
+            case "parquet":
+                # assume we are given a directory of tablename.parquet files that match our database structure
+                if os.path.isdir(source):
+                    for model_name in self.models.keys():
+                        target_file = source + "/" + model_name + ".parquet"
+                        if os.path.isfile(target_file):
+                            self.data[model_name] = pandas.read_parquet(target_file)
+                        else:
+                            raise FileNotFoundError(f"dev_database/DB/populate_from_source: \
+                                                      No source file found for {model_name} table (looking for {target_file}).\n \
+                                                      Source directory must contain files for each of these tables: ({self.models.keys()})")
+                else:
+                    raise NotADirectoryError(f"dev_database/DB/populate_from_source: No such directory '{source}': expecting a directory.")
+
+            case _:
+                raise NotImplementedError(f"dev_database/DB/populate_from_source: \
+                                            {format} not a supported format, please use one of the following: \
+                                            {self.supported_source_formats}")
+
+    def truncate(self, take_num : int = 0, take_frac : float = 0, sampling : str = "last"):
+        # make sure our take_num/take_frac make sense
+        if(((take_num!=0) == (take_frac!=0)) or (take_num < 0 or take_frac < 0)):
+            raise ValueError(f"dev_database/DB/truncate: \
+                               must specify a positive (nonzero) value for only one of take_num or take_frac.")
+        elif(take_num > 0):
+            total_posts = len(self.data["Post"])
+            if(take_num > total_posts):
+                warnings.warn(f"dev_database/DB/truncate: \
+                       {take_num} Post entries requested, but only {total_posts} available. Setting take_num={total_posts}")
+                take_num = total_posts
+        else:
+            if(take_frac > 1):
+                warnings.warn("dev_database/DB/truncate: take_frac > 1.0, setting take_frac=1.0")
+                take_frac = 1.0
+            take_num = round(take_frac*len(self.data["Post"]))
+
+        # only three sampling strategies implemented, default to last n posts
+        if(sampling not in self.supported_sampling_strategies):
+            warnings.warn(f"dev_database/DB/truncate: \
+                            Sampling must be one of {self.supported_sampling_strategies}; setting sampling='last'.")
+            sampling = "last"
+
+        # initial sampling of Post
+        match sampling:
+            case "last":
+                icut = len(self.data["Post"]) - take_num
+                self.data["Post"] = self.data["Post"].iloc[icut:]
+            case "first":
+                self.data["Post"] = self.data["Post"].iloc[:take_num]
+            case "random":
+                self.data["Post"] = self.data["Post"].sample(n=take_num)
+
+        # next, we get the unique DIDs making those posts, as well as the DIDs of mods who interacted with those users
+        user_dids = set(self.data["Post"]["author"])
+        mod_dids  = set(self.data["ModActions"][self.data["ModActions"]["did_user"].isin(user_dids)]["did_mod"])
+        dids = user_dids.union(mod_dids)
+
+        # now with our full set of DIDs, we can retrieve all of the relevant data from the other tables
+        self.data["ModActions"       ] = self.data["ModActions"       ][self.data["ModActions"]["did_user"].isin(dids)] # for mods on user end of mod actions
+        self.data["BotActions"       ] = self.data["BotActions"       ][self.data["BotActions"]["did"     ].isin(dids)]
+        self.data["Account"          ] = self.data["Account"          ][self.data["Account"   ]["did"     ].isin(dids)]
+        self.data["SubscriptionState"] = self.data["SubscriptionState"] # no selection necessary here, it's only one entry (for now)
+
+    def clean(self):
+        # for each table in our list, create a copy of the data and modify (if needed)
+        for table_name,df in self.data.items():
+            # clean copied data column by column, as needed
+            for column in df.columns:
+                # different replacement needs for different columns
+                match column:
+                    case "indexed_at":
+                        replacement_label = "indexed_at"
+
+                        # make copy of column in python date-time format
+                        replacement_data = df["indexed_at"].dt.to_pydatetime()
+                        replacement_data = pandas.Series(replacement_data, dtype=object)
+
+                    case "checked_at":
+                        replacement_label = "checked_at"
+
+                        # replace possibl all-zeroes entries that we can't convert first
+                        date_strings = df["checked_at"]
+                        for i in range(len(date_strings)):
+                            if date_strings.iloc[i] == "0000-00-00 00:00:00":
+                                date_strings.iloc[i] = "0001-01-01 00:00:01"
+
+                        replacement_data = pandas.Series([datetime.strptime(date_strings.iloc[i], "%Y-%m-%d %H:%M:%S") 
+                                                          for i in range(len(date_strings))])
+
+                    case _: # no cleaning needed
+                        continue
+
+                # reindex the dataframe to match the replacement data
+                df = df.set_index(replacement_data.index)
+
+                # swap columns
+                column_loc = df.columns.get_loc(replacement_label)
+                df = df.drop(replacement_label, axis=1)
+                df.insert(column_loc, replacement_label, replacement_data)
+
+                self.data[table_name] = df
+
+    def write(self):
+        # write data for each model
+        for model_name,model in self.models.items():
+            # get database from model, and perform final security check before writing...
+            # REALLY don't want to be accessing the production database here. if we start 
+            # also maintaining MySQL dev databases, can use other checks to distinguish
+            db_conn = model._meta.database
+            if type(db_conn) is peewee.MySQLDatabase:
+                raise ConnectionRefusedError("dev_database/write: MySQL database connection detected during write, \
+                                              might be trying to write to prodution database; aborting.")
+
+            # make the table for our model in the database if it doesn't already exist
+            if model_name not in db_conn.get_tables():
+                db_conn.create_tables([model])
+
+            # get data and fields for our model, and perform an atomic batched write
+            df = self.data[model_name]    
+            model_fields = list(model._meta.fields.values())
+            with db_conn.atomic():
+                for batch in peewee.chunked(df.iloc[:,:].itertuples(index=False), 100): # chunks of 100 for SQLite compatibility
+                    model.insert_many(rows=batch, fields=model_fields).execute()
+
+##
+## main function to be used outside of this module
+##
+
+def build_dev_db(data_source: str, data_format: str = "parquet", database_engine: str = "sqlite"):
+    """Build a smaller, developer-friendly database from source data.
+
+    in:
+        data_souce: string locating un-truncated data to read in
+        data_format: string indicating format of data in source
+        database_engine: string indicating which engine to use for the developer database
+    """
+    # initialize database
+    database_engine = database_engine.lower()
+    match database_engine:
+        case "sqlite":
+            db_conn = peewee.SqliteDatabase("dev_db.db")
+        case _:
+            raise NotImplementedError(f"dev_database/build_dev_db: {database_engine} not supported, sorry!")
+
+    database = DB(db_conn)
+
+    # populate and process our data
+    database.populate_from_source(source=data_source, format=data_format)
+    database.truncate(take_num=50000, sampling="last")
+    database.clean()
+
+    # write to database
+    database.write()

--- a/src/astrofeed_lib/dev_database.py
+++ b/src/astrofeed_lib/dev_database.py
@@ -6,6 +6,8 @@ import warnings
 
 from datetime import datetime
 
+pandas.options.mode.chained_assignment = None  # default='warn' (this suppresses "assigning to copy" warnings)
+
 ##
 ## copies of database.py classes, initialized with a DataBaseProxy (for future flexibility)
 ## 
@@ -237,7 +239,9 @@ class DB():
                         replacement_label = "indexed_at"
 
                         # make copy of column in python date-time format
-                        replacement_data = df["indexed_at"].dt.to_pydatetime()
+                        with warnings.catch_warnings(): # suppresses deprecation warnings from to_pydatetime
+                            warnings.simplefilter("ignore")
+                            replacement_data = df["indexed_at"].dt.to_pydatetime()
                         replacement_data = pandas.Series(replacement_data, dtype=object)
 
                     case "checked_at":

--- a/src/astrofeed_lib/dev_database.py
+++ b/src/astrofeed_lib/dev_database.py
@@ -1,0 +1,195 @@
+import os
+import numpy
+import pandas
+import peewee
+
+from datetime import datetime
+from database import *
+
+def get_db_as_dict(source : str, source_format : str = "parquet"):
+    """ 
+        given a string representing a source to read data from, and another string
+        indicating the format of that source: produce a dictionary linking labels for 
+        ingested tables to dataframes containing the entries in those tables
+
+        in:
+            source       : string specifying the location of data to read in
+            source_format: string indicating format data is stored in
+
+        out:
+            db: dictionary with names of source tables as keys, and dataframes containing 
+                those tables' data as values
+            
+    """
+
+    # initial housekeeping
+    source_formats  = ["parquet"]
+    planned_formats = ["mysql"]
+    source_format   = source_format.lower()
+
+
+    # now we can build the dictionary!
+    db = dict()
+
+    match source_format:
+        case "parquet":
+            # assume we are given a directory of tablename.parquet files, or a single tablename.parquet file
+            if os.path.isdir(source):
+                for filename in os.listdir(source):
+                    tablename = os.path.splitext(filename)[0]
+                    db[tablename] = pandas.read_parquet(source + "/" + filename)
+            else:
+                tablename = os.path.splitext(source)
+                db[tablename] = pandas.read_parquet(source)
+
+        case _:
+            # default case if nothing is matched --- haven't implenented the requested format
+            if source_format in planned_formats:
+                errmsg = f"dev_database/get_db_as_dict: {source_format} is not yet implemented, but it is planned for the future!\nFor now, please use one of the following: {source_formats}"
+            else:
+                errmsg = f"dev_database/get_db_as_dict: {source_format} not a supported format, please use one of the following: {source_formats}"
+            raise NotImplementedError(errmsg)
+
+    return db
+
+def truncate_db(db : dict[str, pandas.DataFrame], take_num : int = 0, take_frac : float = 0, sampling : str = "last"):
+    """ 
+        given a database with Post, Account, ModActions, BotActions, and SubscriptionState tables, 
+        return a truncated database by sampling from Post, then finding all entries in other tables 
+        related to sampled Post entries
+
+        in:
+            db       : dictionary of table labels and corresponding dataframes
+            take_num : number of Post entries to truncate to
+            take_frac: fraction of Post entries to truncate to
+            sampling : whether to take {first, last, random} take_num entries from Post
+
+        out:
+            trunc_db: output dictionary (same structure as input), with truncated Post data and relevant entries 
+                      from other dataframes
+            
+    """
+
+    # make sure our take_num/take_frac make sense
+    if(((take_num!=0) == (take_frac!=0)) or (take_num < 0 or take_frac < 0)):
+        raise ValueError(f"dev_database/truncate_db: must specify a positive (nonzero) value for only one of take_num or take_frac in the argument list.")
+    elif(take_num > 0):
+        total_posts = len(db["Post"])
+        if(take_num > total_posts):
+            print(f"dev_database/truncate_db: {take_num} Post entries requested, but only {total_posts} available. Setting take_num={total_posts}")
+            take_num = total_posts
+    else:
+        if(take_frac > 1):
+            print("dev_database/truncate_db: take_frac is > 1.0, setting take_frac=1.0")
+            take_frac = 1.0
+        take_num = round(take_frac*len(db["Post"]))
+
+    # only three sampling strategies implemented, default to last n posts
+    if(sampling not in ["first", "last", "random"]):
+        print("dev_database/truncate_db: Sampling must be 'first', 'last', or 'random'; setting sampling='last'")
+        sampling = "last"
+
+    # initial sampling of Post
+    trunc_db = dict()
+    match sampling:
+        case "last":
+            icut = len(db["Post"]) - take_num
+            trunc_db["Post"] = db["Post"].iloc[icut:]
+        case "first":
+            trunc_db["Post"] = db["Post"].iloc[:take_num]
+        case "random":
+            trunc_db["Post"] = db["Post"].sample(n=take_num)
+
+    # next, we get unique user ids from those posts, and find which mod actions involved those users
+    user_dids = set(trunc_db["Post"]["author"])
+    trunc_db["ModActions"] = db["ModActions"][db["ModActions"]["did_user"].isin(user_dids)]
+
+    # then, the full set of relevant DIDs are those user DIDs, and the DIDs of mods involved in those actions
+    mod_dids = set(trunc_db["ModActions"]["did_mod"])
+    dids = user_dids.union(mod_dids)
+
+    # now with our full set of DIDs, we can retrieve all of the relevant data from the other tables
+    trunc_db["ModActions"       ] = db["ModActions"       ][db["ModActions"]["did_user"].isin(dids)] # for mods on user end of mod actions
+    trunc_db["BotActions"       ] = db["BotActions"       ][db["BotActions"]["did"     ].isin(dids)]
+    trunc_db["Account"          ] = db["Account"          ][db["Account"   ]["did"     ].isin(dids)]
+    trunc_db["SubscriptionState"] = db["SubscriptionState"] # no selection necessary here, it's only one entry (for now)
+
+    return trunc_db
+
+def clean_db(db : dict[str, pandas.DataFrame]):
+    """ 
+        given a database, return a copy of the database with type conversions applied and replacement values inserted, 
+        where necessary
+
+        in:
+            db: input database, as a dictionary of table labels, and corresponding dataframes holding the data
+
+        out:
+            clean_db: output database (same structure as input), with conversions and corrections applied
+            
+    """
+
+    clean_db = dict()
+
+    # db will be a dict, with each key leading to a dataframe
+    for table in db.keys():
+        df = db[table]
+
+        # loop through df columns, and swap old columns for new
+        for column in df.columns:
+            # different replacement needs for different columns
+            match column:
+                case "indexed_at":
+                    replacement_label = "indexed_at"
+
+                    # make copy of column in python date-time format
+                    replacement_data = df["indexed_at"].dt.to_pydatetime()
+                    replacement_data = pandas.Series(replacement_data, dtype=object)
+
+                case "checked_at":
+                    replacement_label = "checked_at"
+
+                    # possibly will be all-zeroes entries that we can't convert correctly,
+                    # replace those before conversion
+                    date_strings = df["checked_at"]
+                    for i in range(len(date_strings)):
+                        if date_strings.iloc[i] == "0000-00-00 00:00:00":
+                            date_strings.iloc[i] = "0001-01-01 00:00:01"
+
+                    replacement_data = pandas.Series([datetime.strptime(date_strings.iloc[i], "%Y-%m-%d %H:%M:%S") for i in range(len(date_strings))])
+
+                case _: # default
+                    continue
+
+            # reindex the dataframe to match the replacement data
+            df = df.set_index(replacement_data.index)
+
+            # swap columns
+            column_loc = df.columns.get_loc(replacement_label)
+            df = df.drop(replacement_label, axis=1)
+            df.insert(column_loc, replacement_label, replacement_data)
+
+        # now we can fill the new database
+        clean_db[table] = df
+
+    return clean_db
+
+def batch_write_to_db(write_dict : dict[BaseModel, pandas.DataFrame]):
+    """ 
+        given database model classes and associated dataframes, efficiently enter the data from the dataframes into 
+        the corresponding database tables using peewee
+
+        in:
+            write_dict: dictionary associating classes (representing models/tables in a database) with dataframes 
+                        containing entries that should be entered into the database            
+
+    """
+
+    for model,df in zip(write_dict.keys(), write_dict.values()):
+        # get the fields from the model
+        model_fields = list(model._meta.fields.values())
+
+        # atomic batched write
+        with model._meta.database.atomic():
+            for batch in peewee.chunked(df.iloc[:,:].itertuples(index=False), 100):
+                model.insert_many(rows=batch, fields=model_fields).execute()

--- a/src/astrofeed_lib/dev_database.py
+++ b/src/astrofeed_lib/dev_database.py
@@ -302,7 +302,8 @@ def build_dev_db(data_source: str,
                  database_engine: str = "sqlite", 
                  truncation_num: int = 50000,
                  truncation_frac: float = 0.0,
-                 truncation_strat: str = "last"):
+                 truncation_strat: str = "last",
+                 overwrite_existing: bool = False):
     """Build a smaller, developer-friendly database from source data.
 
     in:
@@ -312,8 +313,18 @@ def build_dev_db(data_source: str,
         truncation_num: number of entries in the Post table to truncate to
         truncation_frac: fraction of entries in the Post table to truncate to
         truncation_strat: strategy to use for truncation
+        overwrite_existing: boolean indicating whether to overwrite a pre-existing database
     """
     # initialize database
+    if(os.path.isfile("dev_db.db")):
+        if overwrite_existing:
+            warnings.warn("Found pre-existing dev_db.db, and overwrite_existing=True: removing file.")
+            os.remove("dev_db.db")
+        else:
+            raise FileExistsError("Found pre-existing dev_db.db, and overwrite_existing=False:\n \
+                                   please move, remove, or rename existing dev database, or re-run with \
+                                   argument 'overwrite_existing=True'")
+
     database_engine = database_engine.lower()
     match database_engine:
         case "sqlite":

--- a/src/astrofeed_lib/dev_database.py
+++ b/src/astrofeed_lib/dev_database.py
@@ -297,13 +297,21 @@ class DB():
 ## main function to be used outside of this module
 ##
 
-def build_dev_db(data_source: str, data_format: str = "parquet", database_engine: str = "sqlite"):
+def build_dev_db(data_source: str, 
+                 data_format: str = "parquet", 
+                 database_engine: str = "sqlite", 
+                 truncation_num: int = 50000,
+                 truncation_frac: float = 0.0,
+                 truncation_strat: str = "last"):
     """Build a smaller, developer-friendly database from source data.
 
     in:
         data_souce: string locating un-truncated data to read in
         data_format: string indicating format of data in source
         database_engine: string indicating which engine to use for the developer database
+        truncation_num: number of entries in the Post table to truncate to
+        truncation_frac: fraction of entries in the Post table to truncate to
+        truncation_strat: strategy to use for truncation
     """
     # initialize database
     database_engine = database_engine.lower()
@@ -317,7 +325,7 @@ def build_dev_db(data_source: str, data_format: str = "parquet", database_engine
 
     # populate and process our data
     database.populate_from_source(source=data_source, format=data_format)
-    database.truncate(take_num=50000, sampling="last")
+    database.truncate(take_num=truncation_num, take_frac=truncation_frac, sampling=truncation_strat)
     database.clean()
 
     # write to database

--- a/src/astrofeed_lib/dev_database.py
+++ b/src/astrofeed_lib/dev_database.py
@@ -15,11 +15,11 @@ class DB():
     """Represents a database (including model classes and names), and store data in that database.
 
     class variables:
-        models: dictionary of model names and their classes, reflective of production database
         supported_source_formats: list of formats we can read source data in
         supported_sampling_strategies: list of ways we can truncate source data
 
     instance_variables:
+        models: dictionary of model names and their classes, reflective of production database
         data: dictionary of table names (model names), with data stored for those tables in this instance
 
     methods:


### PR DESCRIPTION
Added file "dev_database.py", defining function `build_dev_database` and support class `DB`, to allow developers to build/re-build smaller local development databases which reflect the structure and contents of the production database.

This file imports model classes from the main "database.py" file, and the DB class uses them in it's constructor (with their database connections replaced by a new connection, passed in as an argument) to set the structure of the developer database. An instance of this class can then obtain data for each of these model classes, truncate and clean that data, and use the model classes (along with their new database connections) to write that data to a database with the same structure as that defined in "database.py".

The `build_dev_db` function requires a user to specify a location for source data, and optionally allows specifying source data format, which engine to use to manage the dev database, what size to make the database and how to sample down to that size, and whether to overwrite an existing database if one is found; by default, it assumes parquet source files and the SQLite engine (both of which are the only supported options at the moment), takes the last 50,000 entries from the Post table, and will not overwrite an existing database if one exists.